### PR TITLE
Fix for Issue #14

### DIFF
--- a/Globals/VerilogParseState.cs
+++ b/Globals/VerilogParseState.cs
@@ -88,7 +88,7 @@ namespace VerilogLanguage
 
                     if (IsNewDelimitedSegment)
                     {
-
+                        IsBuildingEmbeddedSpaceItem = false;
                     }
                     else
                     {


### PR DESCRIPTION
Another one.
Embedded space segment wasn't "turned off" after ':' delimiter. Delimiter was treated just like space. begin keyword too :) 
Delimiter ':' is recognized properly in IsBuildingEmbeddedSpaceItem IF statement, so there is no problem.

I don't know if **else** of modified **if** statement is realy needed at all.

This one tested - works fine :)
![verilog_issue#14](https://user-images.githubusercontent.com/26276653/78462553-8e8cf180-76d3-11ea-930f-7cbc342614e1.png)
